### PR TITLE
Fixed a bug leading to an endless loop in Mesh.cpp line 1047.

### DIFF
--- a/src/kernel/Mesh.cpp
+++ b/src/kernel/Mesh.cpp
@@ -923,7 +923,7 @@ void Mesh::fillNeighborsOneMat(const MeshElement *pEle, const Coordinates &c, fl
 		{
 			if(_periodicX)
 			{
-				maxX = 0;
+				maxX = 1;
 				limit -= _xsize;
 			}
 			else
@@ -972,7 +972,7 @@ void Mesh::fillNeighborsOneMat(const MeshElement *pEle, const Coordinates &c, fl
 		{
 			if(_periodicY)
 			{
-				maxY = 0;
+				maxY = 1;
 				limit -= _ysize;
 			}
 			else
@@ -1021,7 +1021,7 @@ void Mesh::fillNeighborsOneMat(const MeshElement *pEle, const Coordinates &c, fl
 		{
 			if(_periodicZ)
 			{
-				maxZ = 0;
+				maxZ = 1;
 				limit -= _zsize;
 			}
 			else


### PR DESCRIPTION
Max index limits had an overflow value of 0, which were never met in the actual loops, because the overflow set the index to 0, which was then eventually increased by the for statement before checked against 0.