### PR TITLE
Fix migrated MobileParticle causing crash across different materials

### DIFF
--- a/src/okmc/MobileParticle.cpp
+++ b/src/okmc/MobileParticle.cpp
@@ -349,6 +349,11 @@ void MobileParticle::migrate(Kernel::SubDomain *pSub)
 	Mesh::JUMP_ACTIONS jmp = _pDomain->_pMesh->jumpPosition(_coord, delta, pEle, &stateID, _orig, _longHopFactor*_longHopFactor);
 	vector<Particle *> parts;
 	if (jmp != Mesh::JUMP_OK)
+        {
+                pSub->_evLog.performed(mt, Event::MOBILEPARTICLE, _ptype, 0, 7, _state);
+                return;
+    	}
+	if (!fits(pEle))
 	{
 		pSub->_evLog.performed(mt, Event::MOBILEPARTICLE, _ptype, 0, 7, _state);
 		return;

--- a/src/okmc/MobileParticle.cpp
+++ b/src/okmc/MobileParticle.cpp
@@ -349,10 +349,10 @@ void MobileParticle::migrate(Kernel::SubDomain *pSub)
 	Mesh::JUMP_ACTIONS jmp = _pDomain->_pMesh->jumpPosition(_coord, delta, pEle, &stateID, _orig, _longHopFactor*_longHopFactor);
 	vector<Particle *> parts;
 	if (jmp != Mesh::JUMP_OK)
-        {
-                pSub->_evLog.performed(mt, Event::MOBILEPARTICLE, _ptype, 0, 7, _state);
-                return;
-    	}
+  {
+    pSub->_evLog.performed(mt, Event::MOBILEPARTICLE, _ptype, 0, 7, _state);
+    return;
+ 	}
 	if (!fits(pEle))
 	{
 		pSub->_evLog.performed(mt, Event::MOBILEPARTICLE, _ptype, 0, 7, _state);

--- a/src/okmc/MobileParticle.h
+++ b/src/okmc/MobileParticle.h
@@ -25,6 +25,8 @@
 
 #include "Particle.h"
 #include "Defect.h"
+#include "domains/Global.h"
+#include "io/ParameterManager.h"
 #include "kernel/MeshElement.h"
 
 namespace OKMC {
@@ -52,6 +54,7 @@ public:
 	virtual std::vector<Particle *> getParticles() { return std::vector<Particle *>(1,this); }
 	void deletePart(Kernel::SubDomain *, std::vector<Particle *> &);
 	virtual unsigned getState() const { return _state; }
+        bool    fits(Kernel::MeshElement const * const pElem) const { return Domains::global()->PM()->getStates(pElem->getMaterial(), _ptype) > _state; }
 
 	virtual void     restart(std::ostream &) const;
 

--- a/src/okmc/MobileParticle.h
+++ b/src/okmc/MobileParticle.h
@@ -54,7 +54,7 @@ public:
 	virtual std::vector<Particle *> getParticles() { return std::vector<Particle *>(1,this); }
 	void deletePart(Kernel::SubDomain *, std::vector<Particle *> &);
 	virtual unsigned getState() const { return _state; }
-  bool    fits(Kernel::MeshElement const * const pElem) const { return Domains::global()->PM()->getStates(pElem->getMaterial(), _ptype) > _state; }
+        bool    fits(Kernel::MeshElement const * const pElem) const { return Domains::global()->PM()->getStates(pElem->getMaterial(), _ptype) > _state; }
 
 	virtual void     restart(std::ostream &) const;
 

--- a/src/okmc/MobileParticle.h
+++ b/src/okmc/MobileParticle.h
@@ -54,7 +54,7 @@ public:
 	virtual std::vector<Particle *> getParticles() { return std::vector<Particle *>(1,this); }
 	void deletePart(Kernel::SubDomain *, std::vector<Particle *> &);
 	virtual unsigned getState() const { return _state; }
-        bool    fits(Kernel::MeshElement const * const pElem) const { return Domains::global()->PM()->getStates(pElem->getMaterial(), _ptype) > _state; }
+  bool    fits(Kernel::MeshElement const * const pElem) const { return Domains::global()->PM()->getStates(pElem->getMaterial(), _ptype) > _state; }
 
 	virtual void     restart(std::ostream &) const;
 


### PR DESCRIPTION
This pull request causes several unit tests to fail.

The idea was when a MP leaves a material and wants to enter an other one, where its state is not supported, the jump is inhibited.

This was the case when an Int wanted to leave Si and enter SiO2. Int was not configured in SiO2, so its state was unknown there. The extract command crashed when it wanted to retrieve the state name.

This fix solves the crash problem, but probably violates some design ideas elsewhere.