### PR TITLE
Added custom inhomogeneous mesh spacing.

### DIFF
--- a/src/domains/Global.h
+++ b/src/domains/Global.h
@@ -88,7 +88,8 @@ public:
 	ParticleIterator    beginPI();
 	ParticleIterator    endPI();
 
-	void setClient(MCClient *p, const Kernel::Coordinates &m, const Kernel::Coordinates &);
+        void setClient(MCClient *p, const Kernel::Coordinates &m, const Kernel::Coordinates &,
+           std::vector<float> const * const aLinesX = nullptr, std::vector<float> const * const aLinesY = nullptr, std::vector<float> const * const aLinesZ = nullptr);
 
 	void  setTempK(float K);
 	float getTempK() const { return _kelvin; }

--- a/src/io/Parameters.cpp
+++ b/src/io/Parameters.cpp
@@ -86,7 +86,26 @@ float Parameters::getFloat(const string &key) const
 		ERRORMSG("'" << get(key, "float") << "' does not seem to be a proper float");
  	return ret;
 }
- 
+
+std::vector<float> Parameters::getFloats(const string &key) const
+{
+    stringstream text;
+    text << get(key, "array<float>");
+
+    std::vector<float> result;
+    while(!text.eof())
+    {
+        float tmp;
+        text >> tmp;
+        if(!text) {
+            ERRORMSG("'" << get(key, "array<float>") << "' does not seem to be a proper array<float>");
+        }
+        else {} // nothing to do
+        result.push_back(tmp);
+    }
+    return result;
+}
+
 int Parameters::getInt(const string &key) const
 {
 	stringstream ss;

--- a/src/io/Parameters.h
+++ b/src/io/Parameters.h
@@ -44,6 +44,7 @@ public:
 	virtual ~Parameters();
 
     float                                      getFloat(const std::string &key) const;
+    std::vector<float>                         getFloats(const std::string &key) const;
     int                                  	   getInt(const std::string &key) const;
     std::string                          	   getString(const std::string &key) const;
     std::vector<std::string>				   getStrings(const std::string &key, unsigned howMany) const;

--- a/src/kernel/Domain.cpp
+++ b/src/kernel/Domain.cpp
@@ -41,8 +41,9 @@
 using namespace Electrostatics;
 using namespace Kernel;
 
-Domain::Domain(unsigned num, Tcl_Interp *pTcl, const Domains::MCClient *, const Coordinates &m, const Coordinates &M) :
-		_rng_dom(Domains::global()->getFileParameters()->getInt("MC/General/random.seed")),
+Domain::Domain(unsigned num, Tcl_Interp *pTcl, const Domains::MCClient *, const Coordinates &m, const Coordinates &M,
+    std::vector<float> const * const aLinesX, std::vector<float> const * const aLinesY, std::vector<float> const * const aLinesZ) :
+        _rng_dom(Domains::global()->getFileParameters()->getInt("MC/General/random.seed")),
 		_um_mechani("Mechanics/General/update"), _um_poisson("MC/Electrostatic/update"), _domain_number(num)
 {
 	_pMePar = new MeshParam(Domains::global()->PM(), Domains::global()->getFileParameters());
@@ -50,7 +51,7 @@ Domain::Domain(unsigned num, Tcl_Interp *pTcl, const Domains::MCClient *, const 
     _pMPPar = new OKMC::MobileParticleParam(Domains::global()->PM(), Domains::global()->getFileParameters());
 
 	Coordinates mm = m, MM = M;
-	NUTCreator nut(this, mm, MM);
+        NUTCreator nut(this, mm, MM, aLinesX, aLinesY, aLinesZ);
 	_pRM = new RateManager(this);
 	_pMesh = new Mesh(this, mm, MM,
 		nut.getLines(0), nut.getLines(1), nut.getLines(2),

--- a/src/kernel/Domain.h
+++ b/src/kernel/Domain.h
@@ -24,6 +24,7 @@
 #include "UpdateManager.h"
 
 #include <string>
+#include <vector>
 
 namespace LKMC
 {
@@ -71,7 +72,8 @@ class StateManager;
 class Domain
 {
 public:
-    Domain(unsigned num, Tcl_Interp *, const Domains::MCClient *, const Coordinates &m, const Coordinates &M);
+    Domain(unsigned num, Tcl_Interp *, const Domains::MCClient *, const Coordinates &m, const Coordinates &M,
+           std::vector<float> const * const aLinesX = nullptr, std::vector<float> const * const aLinesY = nullptr, std::vector<float> const * const aLinesZ = nullptr);
     void init(bool bFromStream); //is the simulation recreated from a stream?
     ~Domain();
     

--- a/src/kernel/NUTCreator.cpp
+++ b/src/kernel/NUTCreator.cpp
@@ -28,23 +28,35 @@ using std::pair;
 
 namespace Kernel {
 
-NUTCreator::NUTCreator(const Domain *p, Coordinates &m, Coordinates &M)
+NUTCreator::NUTCreator(const Domain *p, Coordinates &m, Coordinates &M,
+               std::vector<float> const * const aLinesX, std::vector<float> const * const aLinesY, std::vector<float> const * const aLinesZ)
 {
-	for(int i=0; i<3; ++i)
-	{
-		_delta[i] = p->_pMePar->_spacing[i];
-		int nBoxes = int(std::floor((M[i] - m[i])/_delta[i] + .5));
-		if(nBoxes < 2)
-			ERRORMSG("Less than 2 boxes in dimension " << i);
-		double inc = (M[i] - m[i])/double(nBoxes);
-		for(int j=0; j<nBoxes; ++j)
-			_lines[i].push_back(m[i] + j*inc);
-		_lines[i].push_back(M[i]);
-		std::string axis = "X";
-		axis[0] += i;
-		LOWMSG("     " << axis << ": (" << m[i] << " - " << M[i] << 
-		 ") nm. " << nBoxes << " elements. Delta = " << inc << " nm.");
-	}
+        if(aLinesX != nullptr && aLinesX->size() > 1u && aLinesY != nullptr && aLinesY->size() > 1u && aLinesZ != nullptr && aLinesZ->size() > 1u) {
+            _lines[0] = *aLinesX;
+            _lines[1] = *aLinesY;
+            _lines[2] = *aLinesZ;
+            LOWMSG("     X: (" << m._x << " - " << M._x << ") nm. " << aLinesX->size() - 1 << " elements. Custom line spacing.");
+            LOWMSG("     Y: (" << m._y << " - " << M._y << ") nm. " << aLinesY->size() - 1 << " elements. Custom line spacing.");
+            LOWMSG("     Z: (" << m._z << " - " << M._z << ") nm. " << aLinesZ->size() - 1 << " elements. Custom line spacing.");
+        }
+        else {
+            for(int i=0; i<3; ++i)
+            {
+                _delta[i] = p->_pMePar->_spacing[i];
+                int nBoxes = int(std::floor((M[i] - m[i])/_delta[i] + .5));
+                if(nBoxes < 2)
+                    ERRORMSG("Less than 2 boxes in dimension " << i);
+                double inc = (M[i] - m[i])/double(nBoxes);
+                for(int j=0; j<nBoxes; ++j) {
+                    _lines[i].push_back(m[i] + j*inc);
+                }
+                _lines[i].push_back(M[i]);
+                std::string axis = "X";
+                axis[0] += i;
+                LOWMSG("     " << axis << ": (" << m[i] << " - " << M[i] <<
+                 ") nm. " << nBoxes << " elements. Delta = " << inc << " nm.");
+            }
+        }
 	LOWMSG("Total " << (_lines[0].size()-1)*(_lines[1].size()-1)*(_lines[2].size()-1) << " elements" );
 }
 

--- a/src/kernel/NUTCreator.h
+++ b/src/kernel/NUTCreator.h
@@ -29,7 +29,8 @@ class Domain;
 class NUTCreator
 {
 public:
-    NUTCreator(const Domain *, Coordinates &m, Coordinates &M);
+    NUTCreator(const Domain *, Coordinates &m, Coordinates &M,
+               std::vector<float> const * const aLinesX, std::vector<float> const * const aLinesY, std::vector<float> const * const aLinesZ);
     ~NUTCreator();
     const std::vector<float> & getLines(int dim) const  { return _lines[dim];  }
 private:


### PR DESCRIPTION
Lets the user override the automatic mesh spacing using custom, inhomogeneous spacing for each axis. Bounds are inferred from the custom spacing. So the line

<pre>init minx=0 maxx=300 miny=0 maxy=60 minz=0 maxz=60 material=material</pre>

becomes

<pre>init linesx={0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32 34 36 38 40 42 44 46 48 50 52 54 56 58 60 63 66 69 72 75 78 81 84 87 90 93 96 99 102 105 108 111 114 117 120 125 130 135 140 145 150 155 160 165 170 175 180 185 190 195 200 205 210 215 220 225 230 235 240 245 250 255 260 265 270 275 280 285 290 295 300} linesy={0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32 34 36 38 40 42 44 46 48 50 52 54 56 58 60} linesz={0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32 34 36 38 40 42 44 46 48 50 52 54 56 58 60} material=material</pre>

Motivation is to be able convert an existing, inhomogeneous mesh into the Tcl function describing the material such that the function can most accurately approximate the original mesh.

All the unit tests passed.

One or more additional unit tests may be needed, I haven't written any.