### PR TITLE
Bugfix for accessing the wrong vector back after pop_back.

### DIFF
--- a/src/okmc/Interface.cpp
+++ b/src/okmc/Interface.cpp
@@ -475,8 +475,8 @@ void Interface::deletePart(Kernel::SubDomain *pSub, vector<Particle *> &parts)
 			delete *it;
 			*it = _particles.back();
 			_particles.pop_back();
-			parts.pop_back();
 			removeFromMap(parts.back()->getPType());
+			parts.pop_back();
 			break;
 		}
 	_pDomain->_pRM->update(this, _me[0]);


### PR DESCRIPTION
Changing the two lines makes more sense. Should parts run out of elements after pop_back, accessing the new back element would be UB.