### PR TITLE
Bugfix for Issue 18

### DIFF
--- a/src/okmc/Interface.cpp
+++ b/src/okmc/Interface.cpp
@@ -209,10 +209,11 @@ void Interface::migrate(Kernel::SubDomain *pSub, unsigned ev)
 	unsigned idx = unsigned(_myID._pt[ev] * pSub->_rng.rand());
 	Particle *pPart = 0;
 	unsigned count = 0;
-	for(vector<Particle *>::iterator it=_particles.begin(); it!=_particles.end(); it++)
-		if((*it)->getPType() == ev && count++ == idx)
+	vector<Particle *>::iterator itPart;
+	for(vector<Particle *>::iterator itPart=_particles.begin(); itPart!=_particles.end(); itPart++)
+		if((*itPart)->getPType() == ev && count++ == idx)
 		{
-			pPart = *it;
+			pPart = *itPart;
 			break;
 		}
 	assert(pPart);
@@ -247,13 +248,8 @@ void Interface::migrate(Kernel::SubDomain *pSub, unsigned ev)
 	if(pnewInt != this)
 	{
 		removeFromMap(ev);
-		for(vector<Particle *>::iterator itpart = _particles.begin(); itpart != _particles.end(); ++itpart)
-			if((*itpart)->getPType() == ev) //find particle and "emit" it
-			{
-				*itpart = _particles.back();
-				_particles.pop_back();
-				break;
-			}
+		*itPart = _particles.back();
+		_particles.pop_back();
 		_pDomain->_pMesh->remove(pPart);
 		_pDomain->_pRM->update(this, _me[0]);
 		pnewInt->insertParticle(pPart); //it inserts the particle in the mesh

--- a/src/okmc/Interface.cpp
+++ b/src/okmc/Interface.cpp
@@ -209,11 +209,10 @@ void Interface::migrate(Kernel::SubDomain *pSub, unsigned ev)
 	unsigned idx = unsigned(_myID._pt[ev] * pSub->_rng.rand());
 	Particle *pPart = 0;
 	unsigned count = 0;
-	vector<Particle *>::iterator itPart;
-	for(vector<Particle *>::iterator itPart=_particles.begin(); itPart!=_particles.end(); itPart++)
-		if((*itPart)->getPType() == ev && count++ == idx)
+	for(vector<Particle *>::iterator it=_particles.begin(); it!=_particles.end(); it++)
+		if((*it)->getPType() == ev && count++ == idx)
 		{
-			pPart = *itPart;
+			pPart = *it;
 			break;
 		}
 	assert(pPart);
@@ -248,8 +247,13 @@ void Interface::migrate(Kernel::SubDomain *pSub, unsigned ev)
 	if(pnewInt != this)
 	{
 		removeFromMap(ev);
-		*itPart = _particles.back();
-		_particles.pop_back();
+		for(vector<Particle *>::iterator itpart = _particles.begin(); itpart != _particles.end(); ++itpart)
+			if(*itpart == pPart) //find particle and "emit" it
+			{
+				*itpart = _particles.back();
+				_particles.pop_back();
+				break;
+			}
 		_pDomain->_pMesh->remove(pPart);
 		_pDomain->_pRM->update(this, _me[0]);
 		pnewInt->insertParticle(pPart); //it inserts the particle in the mesh


### PR DESCRIPTION
The problem was that when we searched for `(*itpart)->getPType() == ev`, the result might have been different from pPart. Then we removed that particle incorrectly, and pPart lived on the old interface. Then, we inserted it into the new one. After this, if one of its referencing pointers wandered into the interface containing the other one, and at this stage the interface got destroyed, a double free error occurred.