### PR TITLE
Added total allowed computation time.

### DIFF
--- a/src/domains/Global.cpp
+++ b/src/domains/Global.cpp
@@ -323,6 +323,12 @@ void Global::anneal(double time, bool bDepth, float depth, long unsigned event)
 	double newDepth = 0;
 	while(_time < endTime && bStop == false)
 	{
+		time_t now;
+		std::time(&now);
+		if(std::difftime(now, _initCPUTime) > _totalAllowedSeconds) {  // TODO implement this in other time-intensive operations
+			WARNINGMSG("Total allowed computation time reached, premature end of annealing.");
+			break;
+		}
 		printTime = _pTimeUpdate->getNextTime();
 		nEvents = 0;
 		double newTime = 0;

--- a/src/domains/Global.h
+++ b/src/domains/Global.h
@@ -23,6 +23,7 @@
 #define GLOBAL_H_
 
 #include <string>
+#include <limits>
 #include <set>
 #include <map>
 #include <fstream>
@@ -91,6 +92,7 @@ public:
         void setClient(MCClient *p, const Kernel::Coordinates &m, const Kernel::Coordinates &,
            std::vector<float> const * const aLinesX = nullptr, std::vector<float> const * const aLinesY = nullptr, std::vector<float> const * const aLinesZ = nullptr);
 
+	void  setTotalAllowedSeconds(float seconds) { _totalAllowedSeconds = seconds; }
 	void  setTempK(float K);
 	float getTempK() const { return _kelvin; }
 	void anneal(double time, bool bDepth, float depth, long unsigned events);
@@ -131,6 +133,7 @@ private:
 	std::string _mechModel;
 
 	bool _bDebug;
+	double _totalAllowedSeconds = std::numeric_limits<double>::max();
 
 	//time steps
 	double _kelvin;

--- a/src/io/InitCmd.cpp
+++ b/src/io/InitCmd.cpp
@@ -69,6 +69,8 @@ int InitCmd::operator()()
 
 	if(specified("temp"))
 		Domains::global()->setTempK(getFloat("temp") + 273.15);
+	if(specified("totalseconds"))
+		Domains::global()->setTotalAllowedSeconds(getFloat("totalseconds"));
 
 	return TCL_OK;	
 }


### PR DESCRIPTION
Running MMonCa under SLURM is dangerous because it is often impossible to estimate the script runtime, and if the job control shuts it down, it can lose hours or days of computation. I've added an additional parameter `totalseconds` to the `init` command to let the user set a somewhat shorter runtime than the one set for the job control.

`init minx=0 maxx=30 miny=0 maxy=60 minz=0 maxz=60 material=material totalseconds=7200`

The check is implemented only for annealing. For other long-lasting commands, it is missing.