### PR TITLE
Added check and quit possbility for total allowed annealing time.

### DIFF
--- a/src/domains/Global.cpp
+++ b/src/domains/Global.cpp
@@ -323,6 +323,12 @@ void Global::anneal(double time, bool bDepth, float depth, long unsigned event)
 	double newDepth = 0;
 	while(_time < endTime && bStop == false)
 	{
+		time_t now;
+		std::time(&now);
+		if(std::difftime(now, _initCPUTime) > _totalAllowedSeconds) {  // TODO implement this in other time-intensive operations
+			WARNINGMSG("Total allowed computation time reached, premature end of annealing.");
+			break;
+		}
 		printTime = _pTimeUpdate->getNextTime();
 		nEvents = 0;
 		double newTime = 0;

--- a/src/domains/Global.h
+++ b/src/domains/Global.h
@@ -23,6 +23,7 @@
 #define GLOBAL_H_
 
 #include <string>
+#include <limits>
 #include <set>
 #include <map>
 #include <fstream>
@@ -91,6 +92,7 @@ public:
         void setClient(MCClient *p, const Kernel::Coordinates &m, const Kernel::Coordinates &,
            std::vector<float> const * const aLinesX = nullptr, std::vector<float> const * const aLinesY = nullptr, std::vector<float> const * const aLinesZ = nullptr);
 
+	void  setTotalAllowedSeconds(float seconds) { _totalAllowedSeconds = seconds; }
 	void  setTempK(float K);
 	float getTempK() const { return _kelvin; }
 	void anneal(double time, bool bDepth, float depth, long unsigned events);
@@ -131,6 +133,7 @@ private:
 	std::string _mechModel;
 
 	bool _bDebug;
+	double _totalAllowedSeconds = std::numeric_limits<double>::max();
 
 	//time steps
 	double _kelvin;

--- a/src/io/InitCmd.cpp
+++ b/src/io/InitCmd.cpp
@@ -69,6 +69,8 @@ int InitCmd::operator()()
 
 	if(specified("temp"))
 		Domains::global()->setTempK(getFloat("temp") + 273.15);
+	if(specified("totalseconds"))
+		Domains::global()->setTotalAllowedSeconds(getFloat("totalseconds"));
 
 	return TCL_OK;	
 }


### PR DESCRIPTION
Batch execution systems like SLURM require an upper runtime to be specified for the job. Exceeding this limit immediately terminates the job. MMonCa runtimes are hard to estimate in advance. By setting the total MMonCa simulation time to a somewhat lower than the job time limit, results of a long-lasting simulation can be printed after the interrupted annealing.

`init minx=0 maxx=30 miny=0 maxy=20 minz=0 maxz=160 material=material totalseconds=60`

Only annealing has this implementation; other long-lasting calculations need to come.