### PR TITLE
Added config dump subcommand.

### DIFF
--- a/src/io/Command.h
+++ b/src/io/Command.h
@@ -53,6 +53,7 @@ public:
     static int Charge	  (ClientData, Tcl_Interp *interp, int argc, const char *argv[]);
     static int UnitTest	  (ClientData, Tcl_Interp *interp, int argc, const char *argv[]);
     
+    Command(Tcl_Interp *p) : _pTcl(p) {}
     Command(Tcl_Interp *, int argc, const char *argv[], bool bPrint=true);
     virtual ~Command();
 

--- a/src/io/ExtractCmd.cpp
+++ b/src/io/ExtractCmd.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ExtractCmd.h"
+#include "FileParameters.h"
 #include "domains/SimData.h"
 #include "domains/MCClient.h"
 #include "kernel/Domain.h"
@@ -94,6 +95,14 @@ int ExtractCmd::operator()()
 	else if(specified("ac.coverage"))
 	{
 		ss << Domains::global()->data()->getACInterfaceCoverage(m, M);
+	}
+	else if(specified("configuration"))
+	{
+		std::string filename;
+		if(specified("filename")) {
+			filename = getString("filename");
+		}
+		Domains::global()->getFileParameters()->dump(ss, filename);
 	}
 	else if(specified("diffusivity"))
 	{

--- a/src/io/FileParameters.cpp
+++ b/src/io/FileParameters.cpp
@@ -42,6 +42,24 @@ FileParameters::~FileParameters()
 			MEDMSG("Parameter " << it->first << " not used");
 }
 
+void FileParameters::dump(std::ostream &aOut, std::string const& aFilename)
+{
+	if(!aFilename.empty()) {
+		aOut << "written into file: " << aFilename;
+		std::ofstream file(aFilename);
+		for(auto const& item : _map)
+		{
+			file << item.first << ':' << item.second.first << ':' << item.second.second << '\n';
+		}
+	}
+	else {
+		for(auto const& item : _map)
+		{
+			aOut << item.first << ':' << item.second.first << ':' << item.second.second << '\n';
+		}
+	}
+}
+
 void FileParameters::openDir(const std::string &szPath, const std::string &key)
 {
    DIR *pDir = opendir(szPath.c_str());

--- a/src/io/FileParameters.h
+++ b/src/io/FileParameters.h
@@ -29,6 +29,7 @@ class FileParameters : public Parameters
    FileParameters(const std::string &szPath);
    FileParameters(std::istream &is) : Parameters(is) {}
    ~FileParameters();
+   void dump(std::ostream &aOut, std::string const& aFilename);
 
   private:
    void openDir (const std::string &szPath,     const std::string &key);

--- a/src/io/LowMsgCmd.cpp
+++ b/src/io/LowMsgCmd.cpp
@@ -24,15 +24,13 @@
 
 namespace IO {
 
-LowMsgCmd::LowMsgCmd(Tcl_Interp *p, int argc, const char *argv[]) : Command(p, argc, argv, false)
+LowMsgCmd::LowMsgCmd(Tcl_Interp *p, int argc, const char *argv[]) : Command(p)
 {
 	for(int i=1; i<argc; ++i)
 	{
 		_out += argv[1];
 		_out += " ";
 	}
-	for(std::map<std::string, bool>::iterator it=_used.begin(); it != _used.end(); ++it)
-		it->second = true;
 }
 
 


### PR DESCRIPTION
Comparing MMonCa effective configurations is not always straightforward, especially when parameters were overruled in the simulation script. I've added an extension to the `extract` command to dump all the actual configuration to the log or a file.

All dump invocations must be preceded by materials definition and init, like:
`param set type=map<string,string> key=MC/General/materials value={ Gas Gas }`
`proc material { x y z } {`
`  return "Gas"`
`}`
`init minx=-2 miny=0 minz=0 maxx=22 maxy=22 maxz=22 material=material`

Dumping to file happens by:
`extract configuration filename="config_start.data"`

To dump to log:
`set configEnd [extract configuration]`
`lowmsg "configEnd:\n$configEnd"`

The format is _key_:_data type_:_value_ like
`AmorphousSilicon/Arsenic/As(formation):arrhenius:0 1`
`AmorphousSilicon/Arsenic/As(map.to.grid):bool:true`

I needed to remove the unnecessary parsing from LowMsgCmd.