### PR TITLE
Fixed division by zero error in test array*.

### DIFF
--- a/src/io/TestCmd.cpp
+++ b/src/io/TestCmd.cpp
@@ -72,6 +72,9 @@ int TestCmd::operator ()()
 			Tcl_AppendResult(_pTcl, out.str().c_str(), 0);
 			return TCL_ERROR;
 		}
+		if(nFields == 0u) {
+			ERRORMSG("No values extracted in \"test array*\". Revise the init and end values and the profile domain.");
+		}
 		out << total/nFields;
 		Tcl_AppendResult(_pTcl, out.str().c_str(), 0);
 		LOWMSG("Test PASSED... continuing");
@@ -113,6 +116,9 @@ int TestCmd::operator ()()
 			out << tag << " Test failed: " << max_err << (bTrue? " > ": " < ") << relerr;
 			Tcl_AppendResult(_pTcl, out.str().c_str(), 0);
 			return TCL_ERROR;
+		}
+		if(nFields == 0u) {
+			ERRORMSG("No values extracted in \"test array*\". Revise the init and end values and the profile domain.");
 		}
 		out << total/nFields;
 		Tcl_AppendResult(_pTcl, out.str().c_str(), 0);
@@ -203,6 +209,9 @@ int TestCmd::operator ()()
 			out << tag << " Test failed: " << max_err << (bTrue? " > ": " < ") << relerr;
 			Tcl_AppendResult(_pTcl, out.str().c_str(), 0);
 			return TCL_ERROR;
+		}
+		if(nFields == 0u) {
+			ERRORMSG("No values extracted in \"test array*\". Revise the init and end values and the profile domain.");
 		}
 		out << total/nFields;
 		Tcl_AppendResult(_pTcl, out.str().c_str(), 0);


### PR DESCRIPTION
I accidentally wrote
`test array="[extract profile defect=* name=B]" value=[expr exp(log(10) * 19.1)] error=0.25 init=20 end=4 tag=allBclustered`
and it resulted in division by zero. Note, the `end` value is smaller than `init`.

This is a fix for this problem, and also the limits not being compatible with the profile domain.