### PR TITLE
Fixed Issue 33.

### DIFF
--- a/test/others/okmc/charge/Si-B/test.mc
+++ b/test/others/okmc/charge/Si-B/test.mc
@@ -17,7 +17,7 @@ param set type=arrhenius key=Silicon/Vacancy/V(formation)    value="1 6"
 
 set T 900
 #set eF 0.33
-set scale 0.720462
+set scale 0.7448065
 set kT [expr 8.6174e-5*($T+273.15)]
 
 init minx=-2 miny=0 minz=0 maxx=$sizeX maxy=$sizeYZ maxz=$sizeYZ material=material
@@ -55,7 +55,7 @@ set eBiM  [param get type=float key=Silicon/Boron/BI(e(-1,0))]
 set CBiM  [expr $CB*$Bif_P*exp(($Bf_E - $Bif_E)/($kB*($T+273.15)))]
 
 
-anneal time=1e25 temp=$T events=2.4e8
+anneal time=1e25 temp=$T events=1.5e8
 
 test tag=$T.I array={ [extract profile.mobile name=I state=0] } value=$CI init=1 end=$sizeX error=.10
 set test  [test tag=$T.BiM array={ [extract profile.mobile name=BI state=-] } value=$CBiM init=1 end=$sizeX error=.17]


### PR DESCRIPTION
I've discovered the magic constant `scale` in [test/others/okmc/charge/Si-B/test.mc line 20](https://github.com/MMonCa/MMonCa/blob/31f8ce8935f0b894657949f43119cd95d11a8f7b/test/others/okmc/charge/Si-B/test.mc#L20). It has no comment, no apparent physical meaning. I thought it must be there for a good reason, so I changed it to let the previously failing profile values meet the calculated `CBi0` value. Note, the profile values started to fail after PR #31.

Now all unit tests run except for the two in #32.

Values before this fix are in the attached spreadsheet.
[issue33.ods](https://github.com/user-attachments/files/21792924/issue33.ods)
