### PR TITLE
Fixed incorrect depth exit condition for annealing. Fixed typo in string literal.

### DIFF
--- a/src/domains/Global.cpp
+++ b/src/domains/Global.cpp
@@ -430,8 +430,7 @@ void Global::anneal(double time, bool bDepth, float depth, long unsigned event)
 		}
 		newTime /= _domains.size(); // TODO consider min(domain time) instead. Would help converge the threads, but not much difference.
 		newDepth /= _domains.size();
-		if(newDepth > 1e35)
-			newDepth = origDepth;
+		bool const validDepth = newDepth < 1e35;
 		_time = newTime;
 		if(bFinished && event == 0 && bDepth == false)
 			_time = endTime;
@@ -446,7 +445,7 @@ void Global::anneal(double time, bool bDepth, float depth, long unsigned event)
 		{
 			if(Tcl_EvalEx(_pGlobalTcl,  "snapshot", -1, 0) != TCL_OK)
 				WARNINGMSG("Snapshot not defined or error.");
-			printOutput(100.*(origDepth - newDepth)/(origDepth - depth));
+			printOutput(validDepth ? 100.*(origDepth - newDepth)/(origDepth - depth) : 0.0);
 		}
 		else if((_time - initTime)/(endTime - initTime) < 1.)
 		{
@@ -454,7 +453,7 @@ void Global::anneal(double time, bool bDepth, float depth, long unsigned event)
 				WARNINGMSG("Snapshot not defined or error.");
 			printOutput(100.*(_time - initTime)/(endTime - initTime));
 		}
-		bStop = bFinished || (event > 0 && nEvents >= event) || (bDepth && newDepth < depth);
+		bStop = bFinished || (event > 0 && nEvents >= event) || (bDepth && validDepth && newDepth < depth);
 	}
 	time_t endCPUTime;
 	std::time(&endCPUTime);

--- a/src/io/ParameterManager.cpp
+++ b/src/io/ParameterManager.cpp
@@ -152,7 +152,7 @@ void ParameterManager::readElements(const IO::FileParameters *p)
 					if(composition[i] == _families[j]._s_family)
 						_materials[mt]._pt[i] = j;
 				if(_materials[mt]._pt[i] == Kernel::UNDEFINED_TYPE)
-					ERRORMSG(getMaterialName(mt) + "Models/material.composition. Cannot understand composition " << composition[i]);
+					ERRORMSG(getMaterialName(mt) + "/Models/material.composition. Cannot understand composition " << composition[i]);
 			}
 		}
 		else


### PR DESCRIPTION
The depth-based exit condition was wrong when no epitaxy occurred at all. It let the annealing end prematurely. I've fixed it.

A string literal had a typo.

All the unit tests run, except for the ones affected by #32 