### PR TITLE
Bugfix for Issue 32.

### DIFF
--- a/src/lkmc/EpiGasParam.h
+++ b/src/lkmc/EpiGasParam.h
@@ -31,7 +31,8 @@
 
 namespace LKMC {
 
-const unsigned MAX_EPI_GASES = 3;
+const unsigned MAX_EPI_GASES = 3;  //                    +1                 +2                  +3
+enum LkmcEvent { LE_FINAL_MIGRATES = MAX_EPI_GASES, LE_FINAL_REMOVED, LE_PRECUR_TO_FINAL, LE_PRECUR_REMOVED, MAX_LKMC_EVENT };
 
 struct EpiGasParam
 {

--- a/src/lkmc/LatticeAtomD2Epi.cpp
+++ b/src/lkmc/LatticeAtomD2Epi.cpp
@@ -69,13 +69,13 @@ void LatticeAtomD2Epi::perform (Kernel::SubDomain *pSub, unsigned eventType)
 
 	if(eventType < MAX_EPI_GASES)
 		performPrecursor(pSub, _pDomain->_pEGPar[_basicMat]->_toPType[eventType], toUpdate);
-	else if(eventType == MAX_EPI_GASES) //mig
+	else if(eventType == LE_FINAL_MIGRATES) //mig
 		performMig(pSub, toUpdate);
-	else if(eventType == MAX_EPI_GASES+1) //depositions or etching
+	else if(eventType == LE_FINAL_REMOVED) //depositions or etching
 		performEtching(pSub, toUpdate);
-	else if(eventType == MAX_EPI_GASES+2)
+	else if(eventType == LE_PRECUR_TO_FINAL)
 		performAdsorption(pSub, toUpdate);
-	else if(eventType == MAX_EPI_GASES+3)
+	else if(eventType == LE_PRECUR_REMOVED)
 		performDesorption(pSub, toUpdate);
 	else
 		ERRORMSG("LatticeAtomD2Epi::Unknown event " << eventType);
@@ -212,18 +212,18 @@ void LatticeAtomD2Epi::performPrecursor(Kernel::SubDomain *pSub, Kernel::P_TYPE 
 	}
 }
 
-// eventType < MAX_EPI_GASES: Deposit the atom specified in the GasParameters;
-// eventType == MAX_EPI_GASES: Migration
-//           == MAX_EPI_GASES+1: etching
-//           == MAX_EPI_GASES+2: final adsorption
-//           == MAX_EPI_GASES+3: precursor desorption
+// eventType <  MAX_EPI_GASES:      Deposit the atom specified in the GasParameters;
+// eventType == LE_FINAL_MIGRATES:  Migration
+//           == LE_FINAL_REMOVED:   etching
+//           == LE_PRECUR_TO_FINAL: final adsorption
+//           == LE_PRECUR_REMOVED:  precursor desorption
 float LatticeAtomD2Epi::getRate(unsigned eventType, float kT) const
 {
-	if((eventType <    MAX_EPI_GASES && _state != LS_AVAILABLE) || //precursor depo
-	   (eventType ==   MAX_EPI_GASES && _state != LS_PERFORMED) || //mig
-	   (eventType == 1+MAX_EPI_GASES && _state != LS_PERFORMED) || //final product etching
-	   (eventType == 2+MAX_EPI_GASES && _state != LS_PRECURSOR) || //final absorption
-	   (eventType == 3+MAX_EPI_GASES && _state != LS_PRECURSOR))   //precursor desorption
+	if((eventType <  MAX_EPI_GASES      && _state != LS_AVAILABLE) || //precursor depo
+	   (eventType == LE_FINAL_MIGRATES  && _state != LS_PERFORMED) || //mig
+	   (eventType == LE_FINAL_REMOVED   && _state != LS_PERFORMED) || //final product etching
+	   (eventType == LE_PRECUR_TO_FINAL && _state != LS_PRECURSOR) || //final absorption
+	   (eventType == LE_PRECUR_REMOVED  && _state != LS_PRECURSOR))   //precursor desorption
 		return 0;
 
 	const LatticeDiamondParam * param = static_cast<const LatticeDiamondParam *>(_pDomain->_pLaPar[_basicMat]);
@@ -234,10 +234,11 @@ float LatticeAtomD2Epi::getRate(unsigned eventType, float kT) const
 	for(unsigned i=0; i<FIRSTN; ++i)
 		if(_neighbors[i])
 			neigStates[static_cast<LatticeAtomD2Epi *>(_neighbors[i])->_state]++;
-	if( (eventType <    MAX_EPI_GASES && neigStates[LS_PERFORMED] == 0) ||
-	    (eventType == 1+MAX_EPI_GASES && neigStates[LS_AVAILABLE] == 0))
+	if( (eventType <     MAX_EPI_GASES && neigStates[LS_PERFORMED] == 0) ||   // precursor depo without any cristalline neighbour
+	    (eventType == LE_FINAL_REMOVED && neigStates[LS_AVAILABLE] == 0) ||   // product etching with no place to go
+		(eventType == LE_PRECUR_TO_FINAL && neigStates[LS_PERFORMED] == 0)) { // final absorption and no cristalline neighbour
 		return 0;
-	assert(eventType != 2+MAX_EPI_GASES || neigStates[LS_PERFORMED]);
+	}
 	Kernel::P_TYPE myType = (eventType < MAX_EPI_GASES ? _pDomain->_pEGPar[_basicMat]->_toPType[eventType]: _type);
 	if(myType == Kernel::UNDEFINED_TYPE) //gas not defined.
 		return 0;
@@ -273,7 +274,7 @@ float LatticeAtomD2Epi::getRate(unsigned eventType, float kT) const
 		float ener = param->_epi[myType]._barrierPrecursor;
 		return pref*exp(-ener/kT);
 	}
-	if(eventType == 3+MAX_EPI_GASES) //precursor desorption
+	if(eventType == LE_PRECUR_REMOVED) //precursor desorption
 	{
 		float pref = _speed_rateFactor * param->_epi[myType]._prefDes;
 		float ener = param->_epi[myType]._barrierDes;
@@ -312,15 +313,15 @@ float LatticeAtomD2Epi::getRate(unsigned eventType, float kT) const
 	float pref = 0;
 	float ener = 0;
 
-	if(eventType == MAX_EPI_GASES) //migration
+	if(eventType == LE_FINAL_MIGRATES) //migration
 		return param->_model_simplified? 0 : getMigRate(binding, kT);
-	else if(eventType == MAX_EPI_GASES+1) //final product etching
+	else if(eventType == LE_FINAL_REMOVED) //final product etching
 	{
 		pref = param->_epi[myType]._prefEtch;
 		if(!param->_model_simplified)
 			ener = -binding;
 	}
-	else if(eventType == MAX_EPI_GASES+2) //attachment of a precursor.
+	else if(eventType == LE_PRECUR_TO_FINAL) //attachment of a precursor.
 	{
 		if(neighborhood._pt.size() == 0)
 			return 0;

--- a/src/lkmc/LatticeAtomD2Epi.h
+++ b/src/lkmc/LatticeAtomD2Epi.h
@@ -37,7 +37,7 @@ public:
 	virtual float getRate(unsigned eventType, float kT) const;
 	virtual void setIndex(unsigned eventType, int idx) { _idx[eventType] = idx; }
 	virtual int  getIndex(unsigned eventType) const { return _idx[eventType]; }
-	virtual unsigned getNEvents() const { return MAX_EPI_GASES+4; } //depositions + mig + etching + final adsorption + desorption
+	virtual unsigned getNEvents() const { return MAX_LKMC_EVENT; } //depositions + mig + etching + final adsorption + desorption
 	//              4         4+12=16   16+12=28         Perfect, but due to periodic BC and twins it can be more.
 	enum { FIRSTN = 9, SECONDN = 30, THIRDN = 64 };
 	virtual unsigned first() const  { return FIRSTN; }
@@ -48,7 +48,7 @@ public:
 	virtual void restart(std::ostream &) const;
 
 private:
-	int _idx[4 + MAX_EPI_GASES];
+	int _idx[MAX_LKMC_EVENT];
 	const static unsigned MAX_ATOM_MIGS = 5;
 	mutable unsigned _rateMigs;  //number of atoms in the cache
 	mutable float    _rateMig[MAX_ATOM_MIGS];  //Mig freq. for each atom

--- a/src/lkmc/LatticeAtomDEpi.h
+++ b/src/lkmc/LatticeAtomDEpi.h
@@ -37,7 +37,7 @@ public:
 	virtual float getRate(unsigned eventType, float kT) const;
 	virtual void setIndex(unsigned eventType, int idx) { _idx[eventType] = idx; }
 	virtual int  getIndex(unsigned eventType) const { return _idx[eventType]; }
-	virtual unsigned getNEvents() const { return MAX_EPI_GASES+4; } //depositions + mig + etching + final adsorption + desorption
+	virtual unsigned getNEvents() const { return MAX_LKMC_EVENT; } //depositions + mig + etching + final adsorption + desorption
 	//              4         4+12=16   16+12=28         Perfect, but due to periodic BC and twins it can be more.
 	enum { FIRSTN = 9, SECONDN = 30, THIRDN = 64 };
 	virtual unsigned first() const  { return FIRSTN; }
@@ -48,7 +48,7 @@ public:
 	virtual void restart(std::ostream &) const;
 
 private:
-	int _idx[4 + MAX_EPI_GASES];
+	int _idx[MAX_LKMC_EVENT];
 	const static unsigned MAX_ATOM_MIGS = 5;
 	mutable unsigned _rateMigs;  //number of atoms in the cache
 	mutable float    _rateMig[MAX_ATOM_MIGS];  //Mig freq. for each atom


### PR DESCRIPTION
I've changed the _symbolic constant + n_ literals to enums for better readability. Here I refer those enums.

`SubDomain::update` and `SubDomain::insert` iterate through all possible event types without considering the actual lattice. In this assertion case, everything was possible below `MAX_LKMC_EVENT`. When the assertion came in `LatticeAtomDEpi::getRate`, the atom in question had only 2 neighbours of type `LS_PRECURSOR`. The assertion failed because we were processing the `LE_PRECURSOR_TO_FINAL` event type. The system simply can't guarantee fulfilling this assertion, so I return 0, as the above 2 conditions do.