### PR TITLE
Bugfix for Issue 47.

### DIFF
--- a/src/lkmc/LatticeAtomD2Epi.cpp
+++ b/src/lkmc/LatticeAtomD2Epi.cpp
@@ -233,7 +233,7 @@ float LatticeAtomD2Epi::getRate(unsigned eventType, float kT) const
 	unsigned neigStates[3] = { 0, 0, 0 }; //array with neighboring states
 	for(unsigned i=0; i<FIRSTN; ++i)
 		if(_neighbors[i])
-			neigStates[static_cast<LatticeAtomD2Epi *>(_neighbors[i])->_state]++;
+			neigStates[_neighbors[i]->getState()]++;
 	if( (eventType <    MAX_EPI_GASES && neigStates[LS_PERFORMED] == 0) ||
 	    (eventType == 1+MAX_EPI_GASES && neigStates[LS_AVAILABLE] == 0))
 		return 0;
@@ -356,7 +356,7 @@ double LatticeAtomD2Epi::getMigRate(float tempEner, float kT) const
 	float returnRate = 0;
 	_rateMigs = 0;
 	for(unsigned i=0; i<SECONDN; ++i)
-		if(_neighbors[i] && static_cast<LatticeAtomD2Epi *>(_neighbors[i])->_state == LS_AVAILABLE)
+		if(_neighbors[i] && _neighbors[i]->getState() == LS_AVAILABLE)
 		{
 			_atomMig[_rateMigs] = static_cast<LatticeAtomD2Epi *>(_neighbors[i]); //candidate for "moving"
 			LatticeAtomD2Epi *candidate = _atomMig[_rateMigs];

--- a/src/lkmc/LatticeAtomDEpi.cpp
+++ b/src/lkmc/LatticeAtomDEpi.cpp
@@ -80,7 +80,7 @@ void LatticeAtomDEpi::perform (Kernel::SubDomain *pSub, unsigned eventType)
 		ERRORMSG("LatticeAtomDEpi::Unknown event " << eventType);
 
 	for(map<int, LatticeAtomDiamond *>::iterator it=toUpdate.begin(); it!=toUpdate.end(); ++it)
-		_pDomain->_pRM->update(it->second, static_cast<LatticeAtomDEpi *>(it->second)->_pElement);
+		_pDomain->_pRM->update(it->second, it->second->getElement());
 	if(_pElement->getNonCrystallineLA() == 0)
 		_pDomain->_pLKMC->cleanLKMCAtoms(_pElement, MOD_Epitaxy);
 }
@@ -232,7 +232,7 @@ float LatticeAtomDEpi::getRate(unsigned eventType, float kT) const
 	unsigned neigStates[3] = { 0, 0, 0 }; //array with neighboring states
 	for(unsigned i=0; i<FIRSTN; ++i)
 		if(_neighbors[i])
-			neigStates[static_cast<LatticeAtomDEpi *>(_neighbors[i])->_state]++;
+			neigStates[_neighbors[i]->getState()]++;
 	if( (eventType <    MAX_EPI_GASES && neigStates[LS_PERFORMED] == 0) ||
 	    (eventType == 1+MAX_EPI_GASES && neigStates[LS_AVAILABLE] == 0))
 		return 0;
@@ -340,7 +340,7 @@ double LatticeAtomDEpi::getMigRate(float tempEner, float kT) const
 	float returnRate = 0;
 	_rateMigs = 0;
 	for(unsigned i=0; i<SECONDN; ++i)
-		if(_neighbors[i] && static_cast<LatticeAtomDEpi *>(_neighbors[i])->_state == LS_AVAILABLE)
+		if(_neighbors[i] && _neighbors[i]->getState() == LS_AVAILABLE)
 		{
 			_atomMig[_rateMigs] = static_cast<LatticeAtomDEpi *>(_neighbors[i]); //candidate for "moving"
 			LatticeAtomDEpi *candidate = _atomMig[_rateMigs];


### PR DESCRIPTION
Occurred in the sanitizer during annealing:
../src/lkmc/LatticeAtomD2Epi.cpp:236:15: runtime error: downcast of address 0x5110011c3c00 which does not point to an object of type 'LatticeAtomD2Epi'

I used already present getters to eliminate the invalid casts.