### PR TITLE
Fixed a bug leading to repeated clusters in parallel simulation.

### DIFF
--- a/src/kernel/Domain.cpp
+++ b/src/kernel/Domain.cpp
@@ -43,7 +43,7 @@ using namespace Kernel;
 
 Domain::Domain(unsigned num, Tcl_Interp *pTcl, const Coordinates &m, const Coordinates &M,
     std::vector<float> const * const aLinesX, std::vector<float> const * const aLinesY, std::vector<float> const * const aLinesZ) :
-        _rng_dom(Domains::global()->getFileParameters()->getInt("MC/General/random.seed")),
+        _rng_dom(Domains::global()->getFileParameters()->getInt("MC/General/random.seed") + num),
 		_um_mechani("Mechanics/General/update"), _um_poisson("MC/Electrostatic/update"), _domain_number(num)
 {
 	_pMePar = new MeshParam(Domains::global()->PM(), Domains::global()->getFileParameters());


### PR DESCRIPTION
The problem was that all the `Kernel::Domain` instances got the same global random number seed. Although there is a good randomisation solution for inserting cascades, each instance used the very same random sequence, leading to repeated patterns across the Z direction.